### PR TITLE
Reimplement Trigraph Fix

### DIFF
--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -106,7 +106,7 @@ enum abstract Binop(Int) from Int to Int {
 			case "<<=": OpShlAssign;
 			case ">>=": OpShrAssign;
 			case ">>>=": OpUshrAssign;
-			case "??=": OpNcoalAssign;
+			case s if (s == "??" + "="): OpNcoalAssign;
 			default: -1;
 		}
 	}
@@ -149,7 +149,7 @@ enum abstract Binop(Int) from Int to Int {
 			case OpShlAssign: "<<=";
 			case OpShrAssign: ">>=";
 			case OpUshrAssign: ">>>=";
-			case OpNcoalAssign: "??=";
+			case OpNcoalAssign: "??" + "=";
 			default: "?";
 		}
 	}

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -106,7 +106,7 @@ enum abstract Binop(Int) from Int to Int {
 			case "<<=": OpShlAssign;
 			case ">>=": OpShrAssign;
 			case ">>>=": OpUshrAssign;
-			case s if (s == "??" + "="): OpNcoalAssign;
+			case _ if (s == "??" + "="): OpNcoalAssign;
 			default: -1;
 		}
 	}


### PR DESCRIPTION
When compiling haxe using C++ in some targets, trigraphs will affect compiled strings turning stuff like "??=" into "#", this issue has been fixed before in 123a7de64a58a4f38dd4497d34b6c820a5a99fb9, but was accidentally brought back in 68358bb08440be64fbd2d36928b192f2119a2385.

Due to this bug, whenever you'd use the ??= operator in hscript, you'd get an `invalid operator: ?` error, this pull request replaces all mentions of "??=" with "??" + "=" to avoid it from turning into `#`.

This pull request has been tested on Linux (where the trigraph issue occurred) and Windows (for compatibility checks).