### PR TITLE
Optimization

### DIFF
--- a/hscript/CustomClass.hx
+++ b/hscript/CustomClass.hx
@@ -43,6 +43,7 @@ class CustomClass implements IHScriptCustomClassBehaviour {
 
 		// __interp.variables = __class.staticInterp.variables;
 		@:privateAccess __interp.usingHandler.usingEntries = __class.ogInterp.usingHandler.usingEntries;
+		@:privateAccess __interp.usingHandler.hasUsingEntries = __class.ogInterp.usingHandler.hasUsingEntries;
 		__interp.publicVariables = __class.ogInterp.publicVariables;
 		__interp.staticVariables = __class.ogInterp.staticVariables;
 		__interp.customClasses = __class.ogInterp.customClasses;
@@ -119,7 +120,7 @@ class CustomClass implements IHScriptCustomClassBehaviour {
 			}
 			customClass.__upperClass = this;
 			__superClass = customClass;
-			@:privateAccess __interp.__instanceFields = __interp.__instanceFields.concat(getSuperFields());
+			@:privateAccess for (f in getSuperFields()) __interp.__instanceFields.set(f, true);
 		} else {
 			if(__cachedFieldSet != null)
 				UnsafeReflect.setField(__class.cl, "__cachedFieldSet", __cachedFieldSet);
@@ -133,7 +134,7 @@ class CustomClass implements IHScriptCustomClassBehaviour {
 				fieldMap.array();
 			}
 			this.__real_fields = disallowCopy;
-			@:privateAccess __interp.__instanceFields = __interp.__instanceFields.concat(disallowCopy);
+			@:privateAccess for (f in disallowCopy) __interp.__instanceFields.set(f, true);
 			__superClass.__real_fields = this.__real_fields;
 			__superClass.__class__fields = this.__class__fields;
 			__superClass.__interp = this.__interp;

--- a/hscript/CustomClassHandler.hx
+++ b/hscript/CustomClassHandler.hx
@@ -52,6 +52,7 @@ class CustomClassHandler implements IHScriptCustomConstructor implements IHScrip
 
 		//__interp.variables = ogInterp.variables;
 		__interp.usingHandler.usingEntries = ogInterp.usingHandler.usingEntries;
+		__interp.usingHandler.hasUsingEntries = ogInterp.usingHandler.hasUsingEntries;
 		__interp.publicVariables = ogInterp.publicVariables;
 		__interp.staticVariables = ogInterp.staticVariables;
 		__interp.customClasses = ogInterp.customClasses;

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -90,18 +90,25 @@ class Interp {
 	private var hasScriptObject(default, null):Bool = false;
 	private var _scriptObjectType(default, null):ScriptObjectType = SNull;
 
-	var __instanceFields:Array<String> = [];
+	var __instanceFields:Map<String, Bool> = new Map();
+
+	/** Converts an array of field names into a lookup map (O(1) membership checks). **/
+	static inline function fieldsToMap(fields:Array<String>):Map<String, Bool> {
+		var m:Map<String, Bool> = new Map();
+		for (f in fields) m.set(f, true);
+		return m;
+	}
 
 	public var scriptObject(default, set):Dynamic;
 	public function set_scriptObject(v:Dynamic) {
 		switch(Type.typeof(v)) {
 			case TClass(c): // Class Access
-				__instanceFields = Type.getInstanceFields(c);
+				__instanceFields = fieldsToMap(Type.getInstanceFields(c));
 				if(v is IHScriptCustomClassBehaviour) {
 					var v:IHScriptCustomClassBehaviour = cast v;
 					var classFields = v.__class__fields;
 					if(classFields != null)
-						__instanceFields = __instanceFields.concat(classFields);
+						for (f in classFields) __instanceFields.set(f, true);
 					inCustomClass = true;
 					_scriptObjectType = SCustomClass;
 				} else if(v is IHScriptCustomAccessBehaviour) {
@@ -115,14 +122,14 @@ class Interp {
 				var cls = Type.getClass(v);
 				switch(Type.typeof(cls)) {
 					case TClass(c): // Static Class Access
-						__instanceFields = Type.getInstanceFields(c);
+						__instanceFields = fieldsToMap(Type.getInstanceFields(c));
 						_scriptObjectType = SStaticClass;
 					default: // Object Access
-						__instanceFields = Reflect.fields(v);
+						__instanceFields = fieldsToMap(Reflect.fields(v));
 						_scriptObjectType = SObject;
 				}
 			default: // Null or other
-				__instanceFields = [];
+				__instanceFields = new Map();
 				_scriptObjectType = SNull;
 		}
 		hasScriptObject = v != null;
@@ -176,6 +183,8 @@ class Interp {
 
 	// TODO: separate cache into a class
 	var varLocationCache:Map<String, VarLocation> = [];
+	/** Caches Type.resolveClass/resolveEnum results for VNotFound identifiers. Classes don't change at runtime, so this is safe to keep. **/
+	var __typeResolveCache:Map<String, Dynamic> = [];
 	public var cacheValid(default, set):Bool = true;
 	function set_cacheValid(valid:Bool):Bool {
 		return cacheValid = valid;
@@ -263,8 +272,58 @@ class Interp {
 			case EIdent(id):
 				var l = locals.get(id);
 				if (l == null) {
+					// Fast path: write directly to the cached location, skipping the varExists/field-scan/resolve re-lookup.
+					if (cacheValid) {
+						var loc = varLocationCache.get(id);
+						if (loc != null) {
+							switch (loc) {
+								case VGlobal:
+									var cur = variables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									variables.set(id, v);
+									return v;
+								case VPublic:
+									var cur = publicVariables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									publicVariables.set(id, v);
+									return v;
+								case VStatic:
+									var cur = staticVariables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									staticVariables.set(id, v);
+									return v;
+								case VScriptObject:
+									if (_scriptObjectType == SObject || isBypassAccessor) {
+										UnsafeReflect.setField(scriptObject, id, v);
+										return v;
+									}
+									UnsafeReflect.setProperty(scriptObject, id, v);
+									return UnsafeReflect.field(scriptObject, id);
+								case VCustomClassBypass:
+									var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+									obj.__allowSetGet = false;
+									var res = obj.hset(id, v);
+									obj.__allowSetGet = true;
+									return res;
+								case VCustomClass:
+									return (cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, v);
+								case VAccessBehaviourBypass:
+									var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+									obj.__allowSetGet = false;
+									var res = obj.hset(id, v);
+									obj.__allowSetGet = true;
+									return res;
+								case VAccessBehaviour:
+									return (cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, v);
+								case VBehaviourClass:
+									return (cast scriptObject:IHScriptCustomBehaviour).hset(id, v);
+								case VScriptObjectGetter, VNotFound:
+									// fall back to the original slow path below
+							}
+						}
+					}
 					if (hasScriptObject && !varExists(id)) {
-						var instanceHasField = __instanceFields.contains(id);
+						var instanceHasField = __instanceFields.exists(id);
 
 						if (_scriptObjectType == SObject && instanceHasField) {
 							UnsafeReflect.setField(scriptObject, id, v);
@@ -292,7 +351,7 @@ class Interp {
 								UnsafeReflect.setProperty(scriptObject, id, v);
 								return UnsafeReflect.field(scriptObject, id);
 							}
-						} else if (__instanceFields.contains('set_$id')) { // setter
+						} else if (__instanceFields.exists('set_$id')) { // setter
 							return UnsafeReflect.getProperty(scriptObject, 'set_$id')(v);
 						} else {
 							varLocationCache.remove(id);
@@ -342,8 +401,58 @@ class Interp {
 				var l = locals.get(id);
 				v = fop(expr(e1), expr(e2));
 				if (l == null) {
+					// Fast path: write directly to the cached location (same semantics as the slow path below).
+					if (cacheValid) {
+						var loc = varLocationCache.get(id);
+						if (loc != null) {
+							switch (loc) {
+								case VGlobal:
+									var cur = variables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									variables.set(id, v);
+									return v;
+								case VPublic:
+									var cur = publicVariables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									publicVariables.set(id, v);
+									return v;
+								case VStatic:
+									var cur = staticVariables.get(id);
+									if (cur is Property) return (cast cur:Property).set(v, isBypassAccessor);
+									staticVariables.set(id, v);
+									return v;
+								case VScriptObject:
+									if (_scriptObjectType == SObject || isBypassAccessor) {
+										UnsafeReflect.setField(scriptObject, id, v);
+										return v;
+									}
+									UnsafeReflect.setProperty(scriptObject, id, v);
+									return UnsafeReflect.field(scriptObject, id);
+								case VCustomClassBypass:
+									var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+									obj.__allowSetGet = false;
+									var res = obj.hset(id, v);
+									obj.__allowSetGet = true;
+									return res;
+								case VCustomClass:
+									return (cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, v);
+								case VAccessBehaviourBypass:
+									var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+									obj.__allowSetGet = false;
+									var res = obj.hset(id, v);
+									obj.__allowSetGet = true;
+									return res;
+								case VAccessBehaviour:
+									return (cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, v);
+								case VBehaviourClass:
+									return (cast scriptObject:IHScriptCustomBehaviour).hset(id, v);
+								case VScriptObjectGetter, VNotFound:
+									// fall back to the original slow path below
+							}
+						}
+					}
 					if(hasScriptObject && !varExists(id)) {
-						var instanceHasField = __instanceFields.contains(id);
+						var instanceHasField = __instanceFields.exists(id);
 
 						if (_scriptObjectType == SObject && instanceHasField) {
 							UnsafeReflect.setField(scriptObject, id, v);
@@ -371,7 +480,7 @@ class Interp {
 								UnsafeReflect.setProperty(scriptObject, id, v);
 								return UnsafeReflect.field(scriptObject, id);
 							}
-						} else if (__instanceFields.contains('set_$id')) { // setter
+						} else if (__instanceFields.exists('set_$id')) { // setter
 							return UnsafeReflect.getProperty(scriptObject, 'set_$id')(v);
 						} else {
 							varLocationCache.remove(id);
@@ -388,7 +497,6 @@ class Interp {
 					}
 				}
 				else {
-					var l = locals.get(id);
 					if (l.r is Property) {
 						var prop:Property = cast l.r;
 						return prop.set(v, isBypassAccessor);
@@ -461,14 +569,14 @@ class Interp {
 						v += delta;
 						if (prop != null)
 							prop.set(v, isBypassAccessor);
-						else {
+						else if (!cachedSet(id, v)) {
 							varLocationCache.remove(id);
 							setVar(id, v);
 						}
 					} else {
 						if (prop != null)
 							prop.set(v + delta, isBypassAccessor);
-						else {
+						else if (!cachedSet(id, v + delta)) {
 							varLocationCache.remove(id);
 							setVar(id, v + delta);
 						}
@@ -618,6 +726,8 @@ class Interp {
 	public function resolve(id:String, doException:Bool = true, allowProperty:Bool = true):Dynamic {
 		if (id == null)
 			return null;
+		// StringTools.trim is O(1) on the leading/trailing whitespace and returns the original
+		// reference when there is none, so it must NOT be pre-guarded by full-string scans.
 		id = StringTools.trim(id);
 
 		if(inCustomClass && id == 'super') {
@@ -656,38 +766,56 @@ class Interp {
 						obj.__allowSetGet = true;
 						res;
 					case VNotFound:
+						var cached = __typeResolveCache.get(id);
+						if (cached != null) return cached;
 						var cl = Type.resolveClass(id);
-						if(cl != null) return cl;
+						if(cl != null) { __typeResolveCache.set(id, cl); return cl; }
 						var en = Type.resolveEnum(id);
-						if(en != null) return en;
+						if(en != null) { __typeResolveCache.set(id, en); return en; }
 						if (doException) error(EUnknownVariable(id));
 						null;
 				}
 			}
 		}
 
-		if (variables.exists(id)) {
+		var v = variables.get(id);
+		if (v != null) {
 			varLocationCache.set(id, VGlobal);
-			return getProperty(variables.get(id), id, allowProperty);
+			return getProperty(v, id, allowProperty);
+		}
+		if (variables.exists(id)) { // exists, but holds a null value
+			varLocationCache.set(id, VGlobal);
+			return null;
+		}
+		v = publicVariables.get(id);
+		if (v != null) {
+			varLocationCache.set(id, VPublic);
+			return getProperty(v, id, allowProperty);
 		}
 		if (publicVariables.exists(id)) {
 			varLocationCache.set(id, VPublic);
-			return getProperty(publicVariables.get(id), id, allowProperty);
+			return null;
+		}
+		v = staticVariables.get(id);
+		if (v != null) {
+			varLocationCache.set(id, VStatic);
+			return getProperty(v, id, allowProperty);
 		}
 		if (staticVariables.exists(id)) {
 			varLocationCache.set(id, VStatic);
-			return getProperty(staticVariables.get(id), id, allowProperty);
+			return null;
 		}
 
-		if(customClasses.exists(id))
-			return customClasses.get(id);
+		var cc = customClasses.get(id);
+		if (cc != null)
+			return cc;
 
 		if (hasScriptObject) {
 			// search in object
 			if (id == "this") {
 				return scriptObject;
 			}
-			var instanceHasField = __instanceFields.contains(id);
+			var instanceHasField = __instanceFields.exists(id);
 
 			if (_scriptObjectType == SObject && instanceHasField) {
 				varLocationCache.set(id, VScriptObject);
@@ -717,16 +845,18 @@ class Interp {
 					varLocationCache.set(id, VScriptObject);
 					return UnsafeReflect.getProperty(scriptObject, id);
 				}
-			} else if (__instanceFields.contains('get_$id')) { // getter
+			} else if (__instanceFields.exists('get_$id')) { // getter
 				return UnsafeReflect.getProperty(scriptObject, 'get_$id')();
 			}
 		}
 		
 		varLocationCache.set(id, VNotFound);
+		var cached = __typeResolveCache.get(id);
+		if (cached != null) return cached;
 		var cl = Type.resolveClass(id);
-		if(cl != null) return cl;
+		if(cl != null) { __typeResolveCache.set(id, cl); return cl; }
 		var en = Type.resolveEnum(id);
-		if(en != null) return en;
+		if(en != null) { __typeResolveCache.set(id, en); return en; }
 		if (doException)
 			error(EUnknownVariable(id));
 		return null;
@@ -734,22 +864,268 @@ class Interp {
 
 	public function invalidateCache():Void {
 		varLocationCache.clear();
+		__typeResolveCache.clear();
 		cacheValid = true;
 	}
 
 	public static var importRedirects:Map<String, String> = new Map();
 	public static function getImportRedirect(className:String):String {
-		return importRedirects.exists(className) ? importRedirects.get(className) : className;
+		var redirect = importRedirects.get(className);
+		return redirect != null ? redirect : className;
 	}
 
 	public var localImportRedirects:Map<String, String> = new Map();
 	public function getLocalImportRedirect(className:String):String {
-		var className = className;
-		if (importRedirects.exists(className))
-			className = importRedirects.get(className);
-		if (localImportRedirects.exists(className))
-			className = localImportRedirects.get(className);
+		var redirect = importRedirects.get(className);
+		if (redirect != null)
+			className = redirect;
+		redirect = localImportRedirects.get(className);
+		if (redirect != null)
+			className = redirect;
 		return className;
+	}
+
+	/** Handles `class Foo { ... }` declarations (extracted from the expr() switch). **/
+	function exprClass(name:String, fields:Array<Expr>, extend:String, interfaces:Array<String>, isFinal:Bool):Void {
+		// TODO: module isolation
+		var oldName:String = name;
+		var hasAlias:Bool = (setAlias != null && beforeAlias == oldName);
+		var toSetName:String = hasAlias ? setAlias : oldName;
+
+		if (customClasses.get(toSetName) != null) {
+			warn(EAlreadyExistingClass(toSetName));
+			return; // ignore it
+		}
+
+		inline function importVar(thing:String):String {
+			if (thing == null)
+				return null;
+			final variable:Class<Any> = variables.exists(thing) ? cast variables.get(thing) : null;
+			return variable == null ? thing : Type.getClassName(variable);
+		}
+		var cls:CustomClassHandler = new CustomClassHandler(this, oldName, fields, importVar(extend), [for (i in interfaces) importVar(i)], isFinal);
+		customClasses.set(toSetName, cls);
+		varLocationCache.remove(toSetName); // a previously-cached VNotFound must not shadow the newly registered class
+		__typeResolveCache.remove(toSetName);
+		if(hasAlias) {
+			customClasses.set(oldName, cls); // Allow usage in the same module
+			varLocationCache.remove(oldName);
+			__typeResolveCache.remove(oldName);
+			beforeAlias = null;
+			setAlias = null;
+		}
+	}
+
+	/** Handles `import` / `using` statements (extracted from the expr() switch). **/
+	function exprImport(clsName:String, aliasAs:Null<String>, isUsing:Bool):Void {
+		if(!importEnabled) return;
+
+		var splitClassName:Array<String> = [for (e in clsName.split(".")) e.trim()];
+		var realClassName = splitClassName.join(".");
+		var claVarName = splitClassName[splitClassName.length - 1];
+		var toSetName = aliasAs != null ? aliasAs : claVarName;
+		var oldClassName = realClassName;
+		var oldSplitName = splitClassName.copy();
+
+		if(variables.exists(toSetName)) { // class is already imported 
+			if(isUsing && !usingHandler.entryExists(toSetName))
+				setUsing(toSetName, variables.get(toSetName)); 
+
+			return;
+		}
+
+		if(customClasses.get(toSetName) != null) { // custom class is already parsed and imported 
+			// NOTE: you will need to create/import 
+			// the custom class first before
+			// setting the extension
+			if(isUsing && !usingHandler.entryExists(toSetName))
+				setCustomClassUsing(toSetName, customClasses.get(toSetName));
+
+			return;
+		}
+		
+		function importResolve(__clsName:String):Null<Dynamic> {
+			var _realClassName = getLocalImportRedirect(__clsName);
+			if(importBlocklist.contains(_realClassName)) {
+				warn(ECustom('Invalid class: $_realClassName is blacklisted'));
+				return null;
+			}
+
+			var _cl = Type.resolveClass(_realClassName);
+			if(_cl == null) _cl = Type.resolveClass('${_realClassName}_HSC');
+			return _cl;
+		}
+
+		var cl = importResolve(realClassName);
+		var en = Type.resolveEnum(realClassName);
+		//trace(realClassName, cl, en, splitClassName);
+
+		// Allow for flixel.ui.FlxBar.FlxBarFillDirection;
+		if(cl == null && en == null) {
+			if(splitClassName.length > 1) {
+				splitClassName.splice(-2, 1); // Remove the last last item
+				realClassName = splitClassName.join(".");
+
+				cl = importResolve(realClassName);
+				en = Type.resolveEnum(realClassName);
+				//trace(realClassName, cl, en, splitClassName);
+			}
+		}
+
+		if(cl == null && en == null) {
+			if(allowStaticImports) { //allows for static imports like "haxe.io.Path.normalize"
+				var clPth:Array<String> = oldSplitName.copy();
+				var funcName:String = clPth.pop();
+				var statField:Dynamic = Reflect.getProperty(Type.resolveClass(StringTools.trim(clPth.join("."))), funcName);
+
+				if(statField != null) {
+					variables.set((toSetName != null && toSetName.length > 0 ? toSetName : funcName), statField);
+					return;
+				}
+			}
+
+			beforeAlias = claVarName;
+			setAlias = aliasAs;
+			if(importFailedCallback == null || !importFailedCallback(oldSplitName, toSetName)){
+				beforeAlias = null;
+				setAlias = null;
+				error(EInvalidClass(oldClassName));
+			}
+		} else {
+			//If the first letter of the alias is not an uppercase letter, then throw an error.
+			//We don't need to worry about this for static imports.
+			if(toSetName != claVarName && !Tools.isUppercase(toSetName)) {
+				error(ECustom("Type aliases must start with an uppercase letter"));
+				return;
+			}
+
+			if(en != null) { // ENUM!!!!
+				if(isUsing) {
+					error(EInvalidClass(oldClassName));
+					return;
+				}
+
+				var enumThingy:HEnum = {};
+				for(c in en.getConstructors()) {
+					try {
+						//UnsafeReflect.setField(enumThingy, c, en.createByName(c));
+						enumThingy.setEnum(c, en.createByName(c));
+					} catch(e) {
+						try {
+							//UnsafeReflect.setField(enumThingy, c, UnsafeReflect.field(en, c));
+							enumThingy.setEnum(c, UnsafeReflect.field(en, c));
+						} catch(ex) {
+							throw e;
+						}
+					}
+				}
+				variables.set(toSetName, enumThingy);
+			} else { //Standard class
+				if(isUsing) setUsing(toSetName, cl);
+				variables.set(toSetName, cl);
+			}
+		}
+	}
+
+	/** Handles `enum` declarations (extracted from the expr() switch). **/
+	function exprEnum(en:EnumDecl, isAbstract:Bool):Void {
+		if(isAbstract) {
+			var enumObj:Dynamic = {};
+			var enumType:String = 'Int';
+			if(en.underlyingType != null) {
+				enumType = switch(en.underlyingType) {
+					case CTPath(path, _):
+						path.join(".");
+					default:
+						''; // ???
+				}
+			}
+			var enumName = en.name;
+			var enumFields = en.fields;
+			// TODO: incremental implicit int value from previous value
+			// i.e.
+			/*
+			enum abstract Numeric(Int) {
+				var Zero; // implicit value: 0
+				var Ten = 10;
+				var Eleven; // implicit value: 11
+			}
+			*/
+			for (i => ef in enumFields) {
+				var fieldName = ef.name;
+				var fieldValue:Dynamic = ef.value != null ? expr(ef.value) : switch(enumType) {
+					case 'Int': i;
+					case 'String': fieldName;
+					default: null;
+				}
+				//var fieldValue:Dynamic = ef.value != null ? exprReturn(ef.value) : i;
+				UnsafeReflect.setField(enumObj, fieldName, fieldValue);
+			}
+			variables.set(enumName, enumObj);
+		} else {
+			var enumThingy:HEnum = {};
+			var enumName = en.name;
+			var enumFields = en.fields;
+			for (i => ef in enumFields) {
+				var fieldName = ef.name;
+				
+				if(ef.args.length < 1) {
+					var enumValue:HEnumValue = {
+						enumName: enumName,
+						fieldName: fieldName,
+						index: i,
+						args: []
+					}
+
+					enumThingy.setEnum(fieldName, enumValue);
+				}
+				else {
+					var params = ef.args;
+					var hasOpt = false, minParams = 0;
+					for (p in params) {
+						if (p.opt)
+							hasOpt = true;
+						else
+							minParams++;
+					}
+						
+					var f = function(args:Array<Dynamic>):HEnumValue {
+						if (((args == null) ? 0 : args.length) != params.length) {
+							if (args.length < minParams) {
+								var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
+								if (enumName != null)
+									str += " for enum '" + enumName + "'";
+								error(ECustom(str));
+							}
+							var args2 = [];
+							var extraParams = args.length - minParams;
+							var pos = 0;
+							for (p in params)
+								if (p.opt) {
+									if (extraParams > 0) {
+										args2.push(args[pos++]);
+										extraParams--;
+									} else
+										args2.push(null);
+								} else
+									args2.push(args[pos++]);
+							args = args2;
+						}
+						return {
+							enumName: enumName,
+							fieldName: fieldName,
+							index: i,
+							args: args
+						};
+					};
+					var f = Reflect.makeVarArgs(f);
+
+					enumThingy.setEnum(fieldName, f);
+				}
+			}
+
+			variables.set(en.name, enumThingy);
+		}
 	}
 
 	// TODO: separate large declarations (EClass, EEnum, etc...) into inline functions
@@ -761,237 +1137,11 @@ class Interp {
 		switch (e) {
 			case EPackage(_):
 			case EClass(name, fields, extend, interfaces, isFinal):
-				// TODO: module isolation
-				var oldName:String = name;
-				var hasAlias:Bool = (setAlias != null && beforeAlias == oldName);
-				var toSetName:String = hasAlias ? setAlias : oldName;
-
-				if (customClasses.exists(toSetName)) {
-					warn(EAlreadyExistingClass(toSetName));
-					return null;// ignore it
-				}
-
-				inline function importVar(thing:String):String {
-					if (thing == null)
-						return null;
-					final variable:Class<Any> = variables.exists(thing) ? cast variables.get(thing) : null;
-					return variable == null ? thing : Type.getClassName(variable);
-				}
-				var cls:CustomClassHandler = new CustomClassHandler(this, oldName, fields, importVar(extend), [for (i in interfaces) importVar(i)], isFinal);
-				customClasses.set(toSetName, cls);
-				if(hasAlias) {
-					customClasses.set(oldName, cls); // Allow usage in the same module
-					beforeAlias = null;
-					setAlias = null;
-				}
+				exprClass(name, fields, extend, interfaces, isFinal);
 			case EImport(clsName, aliasAs, isUsing):
-				if(!importEnabled) return null;
-
-				var splitClassName:Array<String> = [for (e in clsName.split(".")) e.trim()];
-				var realClassName = splitClassName.join(".");
-				var claVarName = splitClassName[splitClassName.length - 1];
-				var toSetName = aliasAs != null ? aliasAs : claVarName;
-				var oldClassName = realClassName;
-				var oldSplitName = splitClassName.copy();
-
-				if(variables.exists(toSetName)) { // class is already imported 
-					if(isUsing && !usingHandler.entryExists(toSetName))
-						setUsing(toSetName, variables.get(toSetName)); 
-
-					return null;
-				}
-
-				if(customClasses.exists(toSetName)) { // custom class is already parsed and imported 
-					// NOTE: you will need to create/import 
-					// the custom class first before
-					// setting the extension
-					if(isUsing && !usingHandler.entryExists(toSetName))
-						setCustomClassUsing(toSetName, customClasses.get(toSetName));
-
-					return null;
-				}
-				
-				function importResolve(__clsName:String):Null<Dynamic> {
-					var _realClassName = getLocalImportRedirect(__clsName);
-					if(importBlocklist.contains(_realClassName)) {
-						warn(ECustom('Invalid class: $_realClassName is blacklisted'));
-						return null;
-					}
-
-					var _cl = Type.resolveClass(_realClassName);
-					if(_cl == null) _cl = Type.resolveClass('${_realClassName}_HSC');
-					return _cl;
-				}
-
-				var cl = importResolve(realClassName);
-				var en = Type.resolveEnum(realClassName);
-				//trace(realClassName, cl, en, splitClassName);
-
-				// Allow for flixel.ui.FlxBar.FlxBarFillDirection;
-				if(cl == null && en == null) {
-					if(splitClassName.length > 1) {
-						splitClassName.splice(-2, 1); // Remove the last last item
-						realClassName = splitClassName.join(".");
-
-						cl = importResolve(realClassName);
-						en = Type.resolveEnum(realClassName);
-						//trace(realClassName, cl, en, splitClassName);
-					}
-				}
-
-				if(cl == null && en == null) {
-					if(allowStaticImports) { //allows for static imports like "haxe.io.Path.normalize"
-						var clPth:Array<String> = oldSplitName.copy();
-						var funcName:String = clPth.pop();
-						var statField:Dynamic = Reflect.getProperty(Type.resolveClass(StringTools.trim(clPth.join("."))), funcName);
-
-						if(statField != null) {
-							variables.set((toSetName != null && toSetName.length > 0 ? toSetName : funcName), statField);
-							return null;
-						}
-					}
-
-					beforeAlias = claVarName;
-					setAlias = aliasAs;
-					if(importFailedCallback == null || !importFailedCallback(oldSplitName, toSetName)){
-						beforeAlias = null;
-						setAlias = null;
-						error(EInvalidClass(oldClassName));
-					}
-				} else {
-					//If the first letter of the alias is not an uppercase letter, then throw an error.
-					//We don't need to worry about this for static imports.
-					if(toSetName != claVarName && !Tools.isUppercase(toSetName)) {
-						error(ECustom("Type aliases must start with an uppercase letter"));
-						return null;
-					}
-
-					if(en != null) { // ENUM!!!!
-						if(isUsing) {
-							error(EInvalidClass(oldClassName));
-							return null;
-						}
-
-						var enumThingy:HEnum = {};
-						for(c in en.getConstructors()) {
-							try {
-								//UnsafeReflect.setField(enumThingy, c, en.createByName(c));
-								enumThingy.setEnum(c, en.createByName(c));
-							} catch(e) {
-								try {
-									//UnsafeReflect.setField(enumThingy, c, UnsafeReflect.field(en, c));
-									enumThingy.setEnum(c, UnsafeReflect.field(en, c));
-								} catch(ex) {
-									throw e;
-								}
-							}
-						}
-						variables.set(toSetName, enumThingy);
-					} else { //Standard class
-						if(isUsing) setUsing(toSetName, cl);
-						variables.set(toSetName, cl);
-					}
-				}
-				return null;
-
+				exprImport(clsName, aliasAs, isUsing);
 			case EEnum(en, isAbstract):
-				if(isAbstract) {
-					var enumObj:Dynamic = {};
-					var enumType:String = 'Int';
-					if(en.underlyingType != null) {
-						enumType = switch(en.underlyingType) {
-							case CTPath(path, _):
-								path.join(".");
-							default:
-								''; // ???
-						}
-					}
-					var enumName = en.name;
-					var enumFields = en.fields;
-					// TODO: incremental implicit int value from previous value
-					// i.e.
-					/*
-					enum abstract Numeric(Int) {
-						var Zero; // implicit value: 0
-						var Ten = 10;
-						var Eleven; // implicit value: 11
-					}
-					*/
-					for (i => ef in enumFields) {
-						var fieldName = ef.name;
-						var fieldValue:Dynamic = ef.value != null ? expr(ef.value) : switch(enumType) {
-							case 'Int': i;
-							case 'String': fieldName;
-							default: null;
-						}
-						//var fieldValue:Dynamic = ef.value != null ? exprReturn(ef.value) : i;
-						UnsafeReflect.setField(enumObj, fieldName, fieldValue);
-					}
-					variables.set(enumName, enumObj);
-				} else {
-					var enumThingy:HEnum = {};
-					var enumName = en.name;
-					var enumFields = en.fields;
-					for (i => ef in enumFields) {
-						var fieldName = ef.name;
-						
-						if(ef.args.length < 1) {
-							var enumValue:HEnumValue = {
-								enumName: enumName,
-								fieldName: fieldName,
-								index: i,
-								args: []
-							}
-
-							enumThingy.setEnum(fieldName, enumValue);
-						}
-						else {
-							var params = ef.args;
-							var hasOpt = false, minParams = 0;
-							for (p in params) {
-								if (p.opt)
-									hasOpt = true;
-								else
-									minParams++;
-							}
-								
-							var f = function(args:Array<Dynamic>):HEnumValue {
-								if (((args == null) ? 0 : args.length) != params.length) {
-									if (args.length < minParams) {
-										var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
-										if (enumName != null)
-											str += " for enum '" + enumName + "'";
-										error(ECustom(str));
-									}
-									var args2 = [];
-									var extraParams = args.length - minParams;
-									var pos = 0;
-									for (p in params)
-										if (p.opt) {
-											if (extraParams > 0) {
-												args2.push(args[pos++]);
-												extraParams--;
-											} else
-												args2.push(null);
-										} else
-											args2.push(args[pos++]);
-									args = args2;
-								}
-								return {
-									enumName: enumName,
-									fieldName: fieldName,
-									index: i,
-									args: args
-								};
-							};
-							var f = Reflect.makeVarArgs(f);
-
-							enumThingy.setEnum(fieldName, f);
-						}
-					}
-
-					variables.set(en.name, enumThingy);
-				}
+				exprEnum(en, isAbstract);
 			case ERegex(e, f):
 				return new EReg(e, f);
 			case EConst(c):
@@ -1154,18 +1304,13 @@ class Interp {
 				returnValue = e == null ? null : expr(e);
 				throw SReturn;
 			case EFunction(params, fexpr, name, _, isPublic, isStatic, isOverride, isPrivate, isFinal, isInline):
-				var __capturedLocals = duplicate(locals);
 				var capturedLocals:Map<String, DeclaredVar> = [];
-
-				var keys = __capturedLocals.keys();
-				var _hasNext = keys.hasNext;
-				var _next = keys.next;
-				while (_hasNext()) {
-					var k = _next();
-					var e = __capturedLocals.get(k);
-					if (e != null && e.depth > 0)
+				var hasCaptured:Bool = false;
+				for (k => e in locals)
+					if (e != null && e.depth > 0) {
 						capturedLocals.set(k, e);
-				}
+						hasCaptured = true;
+					}
 
 				var me = this;
 				var hasOpt = false, minParams = 0;
@@ -1201,7 +1346,7 @@ class Interp {
 					}
 					var old = me.locals, depth = me.depth;
 					me.depth++;
-					me.locals = me.duplicate(capturedLocals);
+					me.locals = hasCaptured ? me.duplicate(capturedLocals) : new Map();
 					for (i in 0...params.length)
 						me.locals.set(params[i].name, {r: args[i], depth: depth});
 					var r:Null<Dynamic> = null;
@@ -1451,7 +1596,7 @@ class Interp {
 	inline function doWhileLoop(econd:Expr, e:Expr):Void {
 		var old = declared.length;
 		do {
-			if (!loopRun(() -> expr(e)))
+			if (!loopBody(e))
 				break;
 		} while (expr(econd) == true);
 		restore(old);
@@ -1460,10 +1605,55 @@ class Interp {
 	inline function whileLoop(econd:Expr, e:Expr):Void {
 		var old = declared.length;
 		while (expr(econd) == true) {
-			if (!loopRun(() -> expr(e)))
+			if (!loopBody(e))
 				break;
 		}
 		restore(old);
+	}
+
+	/** Attempts to write `value` to the cached location of `id`. Returns false if there is no usable cached location (caller falls back to the slow path). **/
+	function cachedSet(id:String, value:Dynamic):Bool {
+		if (!cacheValid) return false;
+		var loc = varLocationCache.get(id);
+		if (loc == null) return false;
+		switch (loc) {
+			case VGlobal:
+				var cur = variables.get(id);
+				if (cur is Property) (cast cur:Property).set(value, isBypassAccessor);
+				else variables.set(id, value);
+			case VPublic:
+				var cur = publicVariables.get(id);
+				if (cur is Property) (cast cur:Property).set(value, isBypassAccessor);
+				else publicVariables.set(id, value);
+			case VStatic:
+				var cur = staticVariables.get(id);
+				if (cur is Property) (cast cur:Property).set(value, isBypassAccessor);
+				else staticVariables.set(id, value);
+			case VScriptObject:
+				if (_scriptObjectType == SObject || isBypassAccessor)
+					UnsafeReflect.setField(scriptObject, id, value);
+				else
+					UnsafeReflect.setProperty(scriptObject, id, value);
+			case VCustomClassBypass:
+				var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+				obj.__allowSetGet = false;
+				obj.hset(id, value);
+				obj.__allowSetGet = true;
+			case VCustomClass:
+				(cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, value);
+			case VAccessBehaviourBypass:
+				var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+				obj.__allowSetGet = false;
+				obj.hset(id, value);
+				obj.__allowSetGet = true;
+			case VAccessBehaviour:
+				(cast scriptObject:IHScriptCustomAccessBehaviour).hset(id, value);
+			case VBehaviourClass:
+				(cast scriptObject:IHScriptCustomBehaviour).hset(id, value);
+			case VScriptObjectGetter, VNotFound:
+				return false;
+		}
+		return true;
 	}
 
 	inline function makeIterator(v:Dynamic, ?allowKeyValue = false):Iterator<Dynamic> {
@@ -1535,26 +1725,26 @@ class Interp {
 			if(isKeyValue)
 				locals.set(ithv, {r: next.key, depth: depth});
 			locals.set(n, {r: isKeyValue ? next.value : next, depth: depth});
-			if (!loopRun(() -> expr(e)))
+			if (!loopBody(e))
 				break;
 		}
 		restore(old);
 	}
 
-	inline function loopRun(f:Void -> Void) {
-		var cont = true;
+	/** Evaluates a loop body, handling SContinue/SBreak/SReturn without allocating a closure per iteration. **/
+	function loopBody(e:Expr):Bool {
 		try {
-			f();
+			expr(e);
 		} catch (err:Stop) {
 			switch (err) {
 				case SContinue:
 				case SBreak:
-					cont = false;
+					return false;
 				case SReturn:
 					throw err;
 			}
 		}
-		return cont;
+		return true;
 	}
 
 	inline function isMap(o:Dynamic):Bool {
@@ -1716,6 +1906,7 @@ class Interp {
 		if (UsingHandler.defaultExtension.exists(name)) {
 			var us:UsingEntry = UsingHandler.defaultExtension.get(name);
 			usingHandler.usingEntries.set(name, us);
+			usingHandler.hasUsingEntries = true;
 			return;
 		}
 		if (obj == null) error(ECustom("Unknown using class " + name));
@@ -1797,7 +1988,7 @@ class Interp {
 			}
 		}
 
-		if (usingHandler.usingEntries.iterator().hasNext()) { // If is not empty
+		if (usingHandler.hasUsingEntries) { // If is not empty
 			var v:Dynamic = null;
 			var clsName:String = o is CustomClassHandler ? cast(o, CustomClassHandler).name : Type.getClassName(Type.getClass(o));
 			// TODO: optimize this

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -86,6 +86,7 @@ class RedeclaredVar {
 @:access(hscript.CustomClass)
 @:analyzer(optimize, local_dce, fusion, user_var_fusion)
 class Interp {
+	private static var _EMPTY_ARGS:Array<Dynamic> = [];
 	private var hasScriptObject(default, null):Bool = false;
 	private var _scriptObjectType(default, null):ScriptObjectType = SNull;
 
@@ -311,10 +312,8 @@ class Interp {
 					return prop.set(v, isBypassAccessor);
 				} else {
 					l.r = v;
-					if (l.depth == 0) {
-						varLocationCache.remove(id);
+					if (l.depth == 0)
 						setVar(id, v);
-					}
 				}
 				// TODO
 			case EField(e, f, s):
@@ -395,10 +394,8 @@ class Interp {
 						return prop.set(v, isBypassAccessor);
 					}
 					l.r = v;
-					if (l.depth == 0) {
-						varLocationCache.remove(id);
-						setVar(id, v);
-					}
+				if (l.depth == 0)
+					setVar(id, v);
 				}
 			case EField(e, f, s):
 				var obj = expr(e);
@@ -451,7 +448,6 @@ class Interp {
 						else
 							l.r = v + delta;
 					}
-					if (l.depth == 0) varLocationCache.remove(id);
 					return v;
 				} else {
 					var v:Dynamic = resolve(id, true, false);
@@ -1126,7 +1122,7 @@ class Interp {
 					default: error(EInvalidOp(op.toString()));
 				}
 			case ECall(e, params):
-				var args:Array<Dynamic> = makeArgs(params);
+				var args:Array<Dynamic> = (params.length > 0) ? makeArgs(params) : _EMPTY_ARGS;
 
 				switch (Tools.expr(e)) {
 					case EField(e, f, s):
@@ -1344,7 +1340,7 @@ class Interp {
 					return arr[index];
 				}
 			case ENew(cl, params, _):
-				var a:Array<Dynamic> = makeArgs(params);
+				var a:Array<Dynamic> = (params.length > 0) ? makeArgs(params) : _EMPTY_ARGS;
 				return cnew(cl, a);
 			case EThrow(e):
 				throw expr(e);

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -176,6 +176,8 @@ class Parser {
 	function initParser( origin:String ) {
 		// line=1 - don't reset line : it might be set manualy
 		preprocStack = [];
+		disableOrOp = false;
+		isVar = false;
 		#if hscriptPos
 		this.origin = origin;
 		readPos = 0;

--- a/hscript/utils/UsingHandler.hx
+++ b/hscript/utils/UsingHandler.hx
@@ -69,11 +69,14 @@ class UsingHandler {
 	@:allow(hscript.CustomClass)
 	@:allow(hscript.CustomClassHandler)
 	public var usingEntries(default, null):Map<String, UsingEntry> = [];
+	/** True once at least one entry is registered. Lets fcall skip the empty-map check without allocating an iterator. **/
+	public var hasUsingEntries:Bool = false;
 
 	public function new() {}
 
 	public function registerEntry(name:String, entry:Dynamic->String->Array<Dynamic>->Dynamic, fields:Array<String>) {
 		usingEntries.set(name, {call: entry, fields: fields});
+		hasUsingEntries = true;
 	}
 
 	public inline function entryExists(name:String):Bool {


### PR DESCRIPTION
A number of optimizations have been added without targeted testing, but from a code‑theoretical perspective, they should all improve runtime performance. The changes are listed below (quite a few, so I may have missed some):

**Interp.hx:**
- Changed the type of the `__instanceFields` variable from `Array<String>` to `Map<String, Bool>`, replacing the original `contains()` operation with `exists()`. `contains()` is O(n), while `exists()` is O(1).
- Added a `__typeResolveCache` variable to cache results of `Type.resolveClass` and `resolveEnum`, avoiding repeated reflection calls.
- Directly write to the corresponding positions using existing `varLocationCache` information. That is, operations like `=`, `+=`, `-=`, etc., can skip the slow path when location information is available.
- Added `private static var _EMPTY_ARGS:Array<Dynamic> = [];` as a reusable object to prevent creating new Arrays at runtime, reducing memory usage and consequent GC pressure.
- Added a `cachedSet` function for a fast path.
- Previously, every variable lookup required `resolve()` (double hash). Now it uses `variables.get(id)` (single hash) plus a null check, and only falls back to `variables.exists(id)` (second hash) when the value is null.
- Split `expr()` into three functions: `exprClass`, `exprImport`, and `exprEnum`. This may improve CPU instruction cache locality, and the compiler may automatically inline suitable functions.
- Replaced the original `loopRun` with the new `loopBody`, eliminating the need to create a closure every time.
- Optimized the code related to `EFunction` creation.
- Added `hasUsingEntries` checks to `UsingHandler.hx`, `Interp.hx`, `CustomClass.hx`, and `CustomClassHandler.hx`. The new implementation is zero‑allocation and does not require creating iterators as before.

**Parser.hx:**
- Fixed an issue where the initParser function did not reset all parameters.

After verification, the code execution results remain consistent with the original—at least from a code review standpoint—and I have run several mods with large scripts and high script volumes without any issues.